### PR TITLE
Refactor: performance improvements

### DIFF
--- a/src/Form43Checker.py
+++ b/src/Form43Checker.py
@@ -30,7 +30,7 @@ class Form43Checker(mobase.IPluginDiagnose):
         )
 
     def version(self):
-        return mobase.VersionInfo(1, 2, 0, mobase.ReleaseType.PRE_ALPHA)
+        return mobase.VersionInfo(1, 2, 0, 0, mobase.ReleaseType.FINAL)
 
     def requirements(self):
         return [

--- a/src/Form43Checker.py
+++ b/src/Form43Checker.py
@@ -6,6 +6,7 @@ from PyQt6.QtCore import QCoreApplication
 
 class Form43Checker(mobase.IPluginDiagnose):
     __organizer: mobase.IOrganizer
+    __invalidPlugins: list[str] = []
 
     def __init__(self):
         super().__init__()
@@ -40,7 +41,8 @@ class Form43Checker(mobase.IPluginDiagnose):
         return []
 
     def activeProblems(self) -> list[int]:
-        if self.__scanPlugins():
+        self.__updateInvalidPlugins()
+        if self.__invalidPlugins:
             return [0]
         else:
             return []
@@ -50,7 +52,6 @@ class Form43Checker(mobase.IPluginDiagnose):
 
     def fullDescription(self, key: int) -> str:
         pluginList = self.__listPlugins()
-        pluginList = [Path(absolutePath).name for absolutePath in pluginList]
         pluginListString = "<br><br>•  " + ("<br>•  ".join(pluginList))
         outputString = self.tr(
             "You have one or more plugins that are not form 44. They are:{0}"
@@ -95,19 +96,16 @@ class Form43Checker(mobase.IPluginDiagnose):
         else:
             return "invalid"
 
-    def __listInvalidFiles(self):
+    def __updateInvalidPlugins(self) -> None:
+        self.__invalidPlugins.clear()
         for file in self.__organizer.findFiles("", "*.es[pm]"):
             if self.__testFile(file):
-                yield file
+                self.__invalidPlugins.append(file)
 
-    def __scanPlugins(self):
-        # Return True if there is at least one invalid file:
-        return next(self.__listInvalidFiles(), False)
-
-    def __listPlugins(self):
+    def __listPlugins(self) -> list[str]:
         return [
-            "{} (form {})".format(file, self.__getForm(file))
-            for file in self.__listInvalidFiles()
+            f"{Path(file).name} (form {self.__getForm(file)})"
+            for file in self.__invalidPlugins
         ]
 
 

--- a/src/Form43Checker.py
+++ b/src/Form43Checker.py
@@ -80,21 +80,13 @@ class Form43Checker(mobase.IPluginDiagnose):
     def tr(self, value: str):
         return QCoreApplication.translate("Form43Checker", value)
 
-    def __testFile(self, path: str) -> bool | None:
+    def __testFile(self, path: str) -> bool:
         version = self.__getForm(path)
-        if isinstance(version, int):
-            return version < 44
-        else:
-            return None
-
-    def __getForm(self, file: str) -> int | str:
-        path = Path(file)
-        if path.is_file():
-            with path.open(mode="rb") as fp:
-                fp.seek(20)
-                return int.from_bytes(fp.read(2), byteorder="little")
-        else:
-            return "invalid"
+        return version != -1 and version < 44
+        
+    def __getForm(self, file: str) -> int:
+        pluginName = Path(file).name
+        return self.__organizer.pluginList().formVersion(pluginName)
 
     def __updateInvalidPlugins(self) -> None:
         self.__invalidPlugins.clear()

--- a/src/Form43Checker.py
+++ b/src/Form43Checker.py
@@ -101,9 +101,6 @@ class Form43Checker(mobase.IPluginDiagnose):
                 yield file
 
     def __scanPlugins(self):
-        if self.__organizer.managedGame().gameName() != "Skyrim Special Edition":
-            return False
-
         # Return True if there is at least one invalid file:
         return next(self.__listInvalidFiles(), False)
 


### PR DESCRIPTION
This refactor makes checking for plugins with form version 43 or lower a bit more efficient by:
* Removing the unnecessary check to ensure the managed game is Skyrim Special Edition (this is already handled by the game dependency requirement)
* Storing the full list of invalid plugins during the `activeProblems` check, so it doesn't need to be done again while creating the `fullDescription`
* ~Using `os.path` for simple file operations like checking for existence and getting the base name, instead of creating full `pathlib.Path` objects to do so~

I also added an extra `0` to the `VersionInfo` as the sub-sub-minor version and changed the release type to final (resolves #7) to make it less confusing. Due to a bug in the `VersionInfo` constructor overloads, this actually results in the same version as the current one. I suspect this is because the release type is converted to an `int` in Python and `mobase.ReleaseType.PRE_ALPHA` has a value of `0`, so the release type is then misinterpreted as the sub-sub-minor version.

Of course, the actual performance impact is minimal, but I did a comparison out of curiosity:

Before:

![before](https://github.com/user-attachments/assets/26517cd0-70bb-4ae3-8116-082f053d56f8)

After:

![after](https://github.com/user-attachments/assets/96911f0b-9b59-43f9-9840-bff5fe78c1d3)

It does appear to have improved as a result of the refactor, especially `fullDescription`.